### PR TITLE
CHANGE collect system memory instead total

### DIFF
--- a/conf/estatsd.config
+++ b/conf/estatsd.config
@@ -17,7 +17,7 @@
         ]},
 
         %% [AdditionalStats, DisabledStats] memory stats. Default:
-        %% Additional = [total, binary, atom, ets, processes]
+        %% Additional = [system, binary, atom, ets, processes]
         %% Disabled = []
         %% You can only add erlang:memory(Name) stats.
         {vm_memory, [

--- a/src/estatsd_sup.erl
+++ b/src/estatsd_sup.erl
@@ -91,7 +91,7 @@ default_enabled_stats(vm_statistics) ->
     ];
 default_enabled_stats(vm_memory) ->
     [
-        total,          %% Total memory currently allocated
+        system,         %% System memory
         binary,         %% Currently allocated for binaries
         atom,           %% Currently allocated for atom
         ets,            %% Currently allocated for ets


### PR DESCRIPTION
From erlang(3erl):

   total = processes + system
   processes = processes_used + ProcessesNotUsed
   system = atom + binary + code + ets + OtherSystem
   atom = atom_used + AtomNotUsed

   RealTotal = processes + RealSystem
   RealSystem = system + MissedSystem

Thus it makes more sense to collect system memory and sum `total` during
the display, if needed.
